### PR TITLE
marlin: hard-code cpu abi list

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -9,6 +9,7 @@ TARGET_BOARD_PLATFORM_GPU := qcom-adreno530
 # Architecture
 TARGET_ARCH := arm64
 TARGET_ARCH_VARIANT := armv8-a
+TARGET_CPU_ABI_LIST := arm64-v8a,armeabi-v7a,armeabi
 TARGET_CPU_ABI := arm64-v8a
 TARGET_CPU_ABI2 :=
 TARGET_CPU_VARIANT := kryo


### PR DESCRIPTION
* It appears different build environments build the prop that this
  ends up becoming (ro.product.cpu.abilist) differently.

* Hard code is so its correct no matter what its built against

Change-Id: Ic1b5d54fa8baee25af6e445c82efb9e6812f67eb